### PR TITLE
bugfix: conf to config

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(builder) {
   builder.hook('before scripts', function(pkg, next) {
 
     // Get all the coffee files from the scripts list
-    var coffee = pkg.conf.scripts.filter(function(file){
+    var coffee = pkg.config.scripts.filter(function(file){
       return path.extname(file) === '.coffee';
     });
 


### PR DESCRIPTION
I think I found a tiny typo.

Invocation per README.md instructions resulted in:

```
TypeError: Cannot read property 'scripts' of undefined
```

Adding a "console.log(JSON.stringify(pkg));" displayed something like:

```
{"_cache":{},"_hooks":{"before scripts":[null]},"_files":{},"_js":"","urlPrefix":"","copy":false,"dir":"xxx","root":true,"basename":"xxx","globalLookupPaths":["xxx/components"],"lookupPaths":[],"ignored":{"scripts":["xxx"],"styles":[],"files":[],"images":[],"fonts":[]},"config":{"name":"xxx","version":"0.0.0","dependencies":{"xxx":"0.0.0"},"scripts":["xxx.coffee"],"paths":[]},"_events":{},"assetsDest":"build"}
```

The "conf" property is absent, and "config" is existent.
