### PR TITLE
Check for existence of scripts field in component.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var fs = require('fs');
 module.exports = function(builder) {
   builder.hook('before scripts', function(pkg, next) {
 
+    // No scripts field in the component.json file
+    if (pkg.config.scripts === undefined) return next();
+
     // Get all the coffee files from the scripts list
     var coffee = pkg.config.scripts.filter(function(file){
       return path.extname(file) === '.coffee';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-coffee",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CoffeeScript plugin for Component",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`component-coffee` currently crashes if there is no `scripts` field in the component.json.
Fixes this issue & bumps version.
